### PR TITLE
Fix arch name on arm64 linux

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -35,12 +35,16 @@ download_release() {
   version="$1"
   filename="$2"
   arch="$(uname -m)"
-  
+
   case "$OSTYPE" in
     linux*) os=linux ;;
     darwin*) os=macos ;;
     msys*) os=mingw ;;
     *) fail "no prebuilt package for os" ;;
+  esac
+
+  case "$arch" in
+    aarch64) arch="arm64" ;;
   esac
 
   if [ "$version" -ge 23 ]; then


### PR DESCRIPTION
On arm64 Linux, the arch string reported by `uname -m` is `aarch64`. But the official `wasi-sdk` arch string used in the URL is `arm64`.